### PR TITLE
Gateway application.yml 11/28 cors 실습 설정 추가

### DIFF
--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -11,12 +11,32 @@ spring:
     password: guest
   cloud:
     gateway:
+      globalcors:
+        cors-configurations:
+          "[/**]": # 모든 경로에 대한 CORS 설정
+            allowed-origins:
+              - "http://localhost:3000"
+            allowed-methods:
+              - GET
+              - POST
+              - PUT
+              - DELETE
+              - OPTIONS
+            allowed-headers:
+              - "Content-Type"
+              - "Authorization"
+              - "X-Requested-With"
+            allow-credentials: true
       default-filters:
         - name: GlobalFilter
           args:
             baseMessage: Traplan Cloud Gateway Global Filter
             preLogger: true
             postLogger: true
+        - name: DedupeResponseHeader
+          args:
+            name: Access-Control-Allow-Credentials Access-Control-Allow-Origin
+            strategy: RETAIN_FIRST
       routes:
         - id: member-service
           uri: lb://MEMBER-SERVICE


### PR DESCRIPTION
gateway-service, application.yml 
globalcors 추가, 
default-filters: - name: DedupeResponseHeader 추가

- Note: 
  각 서비스의 common.configs.CorsConfig.java 는 삭제 처리 필요함. 